### PR TITLE
Add geometry classes factories with default values

### DIFF
--- a/src/main/kotlin/frc/robot/lib/ExtensionFunctions.kt
+++ b/src/main/kotlin/frc/robot/lib/ExtensionFunctions.kt
@@ -2,9 +2,7 @@ package frc.robot.lib
 
 import com.pathplanner.lib.util.FlippingUtil
 import edu.wpi.first.math.geometry.Pose2d
-import edu.wpi.first.math.geometry.Pose3d
 import edu.wpi.first.math.geometry.Rotation2d
-import edu.wpi.first.math.geometry.Rotation3d
 import edu.wpi.first.math.geometry.Translation2d
 import edu.wpi.first.math.kinematics.ChassisSpeeds
 import edu.wpi.first.units.Units
@@ -84,9 +82,6 @@ fun Command.finallyDo(command: Command): WrapperCommand =
             command.schedule()
         }
     )
-
-fun Pose2d.toPose3d(): Pose3d =
-    Pose3d(x, y, 0.0, Rotation3d(0.0, 0.0, rotation.radians))
 
 fun Pose2d.flip(): Pose2d = FlippingUtil.flipFieldPose(this)
 

--- a/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
+++ b/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
@@ -3,6 +3,7 @@ package frc.robot.lib
 import edu.wpi.first.math.geometry.Pose2d
 import edu.wpi.first.math.geometry.Rotation2d
 import edu.wpi.first.math.geometry.Translation2d
+import edu.wpi.first.math.geometry.Translation3d
 import edu.wpi.first.units.Units.Meters
 import edu.wpi.first.units.measure.Distance
 
@@ -23,3 +24,9 @@ fun getPose2d(x: Double = 0.0, y: Double = 0.0, rotation: Rotation2d = Rotation2
 
 fun getPose2d(x: Distance = Meters.zero(), y: Distance = Meters.zero(), rotation: Rotation2d = Rotation2d()) =
     Pose2d(x, y, rotation)
+
+
+fun getTranslation3d(x: Double = 0.0, y: Double = 0.0, z: Double = 0.0) = Translation3d(x, y, z)
+
+fun getTranslation3d(x: Distance = Meters.zero(), y: Distance = Meters.zero(), z: Distance = Meters.zero()) =
+    Translation3d(x, y, z)

--- a/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
+++ b/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
@@ -35,3 +35,17 @@ fun getRotation3d(roll: Double = 0.0, pitch: Double = 0.0, yaw: Double = 0.0) = 
 
 fun getRotation3d(roll: Angle = Rotations.zero(), pitch: Angle = Rotations.zero(), yaw: Angle = Rotations.zero()) =
     Rotation3d(roll, pitch, yaw)
+
+
+fun getPose3d(translation: Translation3d = Translation3d(), rotation: Rotation3d = Rotation3d()) =
+    Pose3d(translation, rotation)
+
+fun getPose3d(x: Double = 0.0, y: Double = 0.0, z: Double = 0.0, rotation: Rotation3d = Rotation3d()) =
+    Pose3d(x, y, z, rotation)
+
+fun getPose3d(
+    x: Distance = Meters.zero(),
+    y: Distance = Meters.zero(),
+    z: Distance = Meters.zero(),
+    rotation: Rotation3d = Rotation3d(),
+) = Pose3d(x, y, z, rotation)

--- a/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
+++ b/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
@@ -1,5 +1,6 @@
 package frc.robot.lib
 
+import edu.wpi.first.math.geometry.Pose2d
 import edu.wpi.first.math.geometry.Rotation2d
 import edu.wpi.first.math.geometry.Translation2d
 import edu.wpi.first.units.Units.Meters
@@ -13,3 +14,12 @@ fun getTranslation2d(x: Distance = Meters.zero(), y: Distance = Meters.zero()) =
 fun getRotation2d(x: Double = 0.0, y: Double = 0.0) = Rotation2d(x, y)
 
 fun getRotation2d(x: Distance = Meters.zero(), y: Distance = Meters.zero()) = Rotation2d(x.`in`(Meters), y.`in`(Meters))
+
+
+fun getPose2d(translation: Translation2d = Translation2d(), rotation: Rotation2d = Rotation2d()) =
+    Pose2d(translation, rotation)
+
+fun getPose2d(x: Double = 0.0, y: Double = 0.0, rotation: Rotation2d = Rotation2d()) = Pose2d(x, y, rotation)
+
+fun getPose2d(x: Distance = Meters.zero(), y: Distance = Meters.zero(), rotation: Rotation2d = Rotation2d()) =
+    Pose2d(x, y, rotation)

--- a/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
+++ b/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
@@ -1,10 +1,9 @@
 package frc.robot.lib
 
-import edu.wpi.first.math.geometry.Pose2d
-import edu.wpi.first.math.geometry.Rotation2d
-import edu.wpi.first.math.geometry.Translation2d
-import edu.wpi.first.math.geometry.Translation3d
+import edu.wpi.first.math.geometry.*
 import edu.wpi.first.units.Units.Meters
+import edu.wpi.first.units.Units.Rotations
+import edu.wpi.first.units.measure.Angle
 import edu.wpi.first.units.measure.Distance
 
 fun getTranslation2d(x: Double = 0.0, y: Double = 0.0) = Translation2d(x, y)
@@ -30,3 +29,9 @@ fun getTranslation3d(x: Double = 0.0, y: Double = 0.0, z: Double = 0.0) = Transl
 
 fun getTranslation3d(x: Distance = Meters.zero(), y: Distance = Meters.zero(), z: Distance = Meters.zero()) =
     Translation3d(x, y, z)
+
+
+fun getRotation3d(roll: Double = 0.0, pitch: Double = 0.0, yaw: Double = 0.0) = Rotation3d(roll, pitch, yaw)
+
+fun getRotation3d(roll: Angle = Rotations.zero(), pitch: Angle = Rotations.zero(), yaw: Angle = Rotations.zero()) =
+    Rotation3d(roll, pitch, yaw)

--- a/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
+++ b/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
@@ -1,0 +1,1 @@
+package frc.robot.lib

--- a/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
+++ b/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
@@ -1,5 +1,6 @@
 package frc.robot.lib
 
+import edu.wpi.first.math.geometry.Rotation2d
 import edu.wpi.first.math.geometry.Translation2d
 import edu.wpi.first.units.Units.Meters
 import edu.wpi.first.units.measure.Distance
@@ -7,3 +8,8 @@ import edu.wpi.first.units.measure.Distance
 fun getTranslation2d(x: Double = 0.0, y: Double = 0.0) = Translation2d(x, y)
 
 fun getTranslation2d(x: Distance = Meters.zero(), y: Distance = Meters.zero()) = Translation2d(x, y)
+
+
+fun getRotation2d(x: Double = 0.0, y: Double = 0.0) = Rotation2d(x, y)
+
+fun getRotation2d(x: Distance = Meters.zero(), y: Distance = Meters.zero()) = Rotation2d(x.`in`(Meters), y.`in`(Meters))

--- a/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
+++ b/src/main/kotlin/frc/robot/lib/GeometryFactories.kt
@@ -1,1 +1,9 @@
 package frc.robot.lib
+
+import edu.wpi.first.math.geometry.Translation2d
+import edu.wpi.first.units.Units.Meters
+import edu.wpi.first.units.measure.Distance
+
+fun getTranslation2d(x: Double = 0.0, y: Double = 0.0) = Translation2d(x, y)
+
+fun getTranslation2d(x: Distance = Meters.zero(), y: Distance = Meters.zero()) = Translation2d(x, y)


### PR DESCRIPTION
- Create geometry factories file
- Add `Translation2d` factories
- Add `Rotation2d` factories
- Add `Pose2d` factories
- Add `Translation3d` factories
- Add `Rotation3d` factories
- Add `Pose3d` factories
- Remove `Pose2d` to `Pose3d` extension function because a WPILib alternative exists

This will be used in #75, among others.