### PR TITLE
Calibrate Intake

### DIFF
--- a/src/main/kotlin/frc/robot/subsystems/intake/extender/Extender.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/extender/Extender.kt
@@ -25,7 +25,7 @@ class Extender(private val io: ExtenderIO) : SubsystemBase() {
         root.append(LoggedMechanismLigament2d("ExtenderLigament", 0.569, 0.0))
 
     private val tuningPositionMeters =
-        LoggedNetworkNumber("Tuning/Extender/Position", 0.0)
+        LoggedNetworkNumber("/Tuning/Extender/Position", 0.0)
 
     val position: () -> Distance = { io.inputs.position }
 
@@ -54,7 +54,8 @@ class Extender(private val io: ExtenderIO) : SubsystemBase() {
             )
             .withName("Extender/setVoltage")
 
-    fun tuningPosition(): Command = run {
+    fun tuningPosition(): Command = runOnce {
+        setpoint = Units.Meters.of(tuningPositionMeters.get())
         io.setPosition(Units.Meters.of(tuningPositionMeters.get()))
     }
 

--- a/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderConstants.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderConstants.kt
@@ -1,10 +1,7 @@
 package frc.robot.subsystems.intake.extender
 
 import edu.wpi.first.units.Units
-import edu.wpi.first.units.measure.Current
-import edu.wpi.first.units.measure.Distance
-import edu.wpi.first.units.measure.MomentOfInertia
-import edu.wpi.first.units.measure.Voltage
+import edu.wpi.first.units.measure.*
 import frc.robot.lib.Gains
 import frc.robot.lib.selectGainsBasedOnMode
 
@@ -13,15 +10,15 @@ val RESET_VOLTAGE: Voltage = Units.Volts.of(0.0)
 val PINION_RADIUS: Distance = Units.Millimeters.of(15.22)
 val MOMENT_OF_INERTIA: MomentOfInertia = Units.KilogramSquareMeters.of(0.003)
 val RESET_CURRENT_THRESHOLD: Current = Units.Amps.of(0.0)
-val POSITION_TOLERANCE: Distance = Units.Centimeters.of(0.7)
-val MAX_EXTENSION: Distance = Units.Meters.of(0.0)
-val MIN_EXTENSION: Distance = Units.Meters.of(0.0)
+val POSITION_TOLERANCE: Distance = Units.Centimeters.of(0.1)
+val MAX_EXTENSION: Angle = Units.Rotations.of(6.7)
+val MIN_EXTENSION: Angle = Units.Rotations.of(-6.3)
 const val SAFETY_DEBOUNCE = 1.0
 
-val GAINS = selectGainsBasedOnMode(Gains(1.5), Gains(kP = 0.5, kD = 0.2))
+val GAINS = selectGainsBasedOnMode(Gains(2.0), Gains(kP = 0.5, kD = 0.2))
 
 enum class Positions(val position: Distance) {
-    EXTENDED(Units.Meters.of(0.3)),
+    EXTENDED(Units.Meters.of(0.4)),
     RETRACTED(Units.Meters.of(0.0));
 
     fun getLoggingName() =

--- a/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderConstants.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderConstants.kt
@@ -18,7 +18,7 @@ val MAX_EXTENSION: Distance = Units.Meters.of(0.0)
 val MIN_EXTENSION: Distance = Units.Meters.of(0.0)
 const val SAFETY_DEBOUNCE = 1.0
 
-val GAINS = selectGainsBasedOnMode(Gains(), Gains(kP = 0.5, kD = 0.2))
+val GAINS = selectGainsBasedOnMode(Gains(1.5), Gains(kP = 0.5, kD = 0.2))
 
 enum class Positions(val position: Distance) {
     EXTENDED(Units.Meters.of(0.3)),

--- a/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderIOReal.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderIOReal.kt
@@ -75,7 +75,6 @@ class ExtenderIOReal : ExtenderIO {
                 position.toAngle(PINION_RADIUS, GEAR_RATIO)
             )
         )
-        println(position.toAngle(PINION_RADIUS, GEAR_RATIO))
     }
 
     override fun setVoltage(voltage: Voltage) {

--- a/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderIOReal.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderIOReal.kt
@@ -41,7 +41,7 @@ class ExtenderIOReal : ExtenderIO {
                 MotorOutput =
                     MotorOutputConfigs().apply {
                         Inverted = InvertedValue.Clockwise_Positive
-                        NeutralMode = NeutralModeValue.Coast
+                        NeutralMode = NeutralModeValue.Brake
                     }
 
                 CurrentLimits =

--- a/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderIOReal.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderIOReal.kt
@@ -6,7 +6,7 @@ import com.ctre.phoenix6.configs.MotorOutputConfigs
 import com.ctre.phoenix6.configs.Slot0Configs
 import com.ctre.phoenix6.configs.SoftwareLimitSwitchConfigs
 import com.ctre.phoenix6.configs.TalonFXConfiguration
-import com.ctre.phoenix6.controls.MotionMagicTorqueCurrentFOC
+import com.ctre.phoenix6.controls.PositionVoltage
 import com.ctre.phoenix6.controls.VoltageOut
 import com.ctre.phoenix6.hardware.TalonFX
 import com.ctre.phoenix6.signals.InvertedValue
@@ -20,19 +20,15 @@ import frc.robot.lib.toDistance
 class ExtenderIOReal : ExtenderIO {
     override val inputs = LoggedExtenderInputs()
     private val motor = TalonFX(MOTOR_ID)
-    private val positionControl = MotionMagicTorqueCurrentFOC(0.0)
+    private val positionControl = PositionVoltage(0.0)
     private val voltageRequest = VoltageOut(0.0)
 
     private val softLimitsConfig =
         SoftwareLimitSwitchConfigs().apply {
             ForwardSoftLimitEnable = true
             ReverseSoftLimitEnable = true
-            ForwardSoftLimitThreshold =
-                MAX_EXTENSION.toAngle(PINION_RADIUS, GEAR_RATIO)
-                    .`in`(Units.Rotations)
-            ReverseSoftLimitThreshold =
-                MIN_EXTENSION.toAngle(PINION_RADIUS, GEAR_RATIO)
-                    .`in`(Units.Rotations)
+            ForwardSoftLimitThreshold = MAX_EXTENSION.`in`(Units.Rotations)
+            ReverseSoftLimitThreshold = MIN_EXTENSION.`in`(Units.Rotations)
         }
 
     init {
@@ -79,6 +75,7 @@ class ExtenderIOReal : ExtenderIO {
                 position.toAngle(PINION_RADIUS, GEAR_RATIO)
             )
         )
+        println(position.toAngle(PINION_RADIUS, GEAR_RATIO))
     }
 
     override fun setVoltage(voltage: Voltage) {

--- a/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderPorts.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/extender/ExtenderPorts.kt
@@ -1,3 +1,3 @@
 package frc.robot.subsystems.intake.extender
 
-const val MOTOR_ID = 0
+const val MOTOR_ID = 11

--- a/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerConstants.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerConstants.kt
@@ -4,7 +4,7 @@ import edu.wpi.first.units.Units
 import edu.wpi.first.units.measure.MomentOfInertia
 import edu.wpi.first.units.measure.Voltage
 
-val INTAKE_VOLTAGE: Voltage = Units.Volts.of(-0.5 * 12.0)
+val INTAKE_VOLTAGE: Voltage = Units.Volts.of(-0.7 * 12.0)
 val OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(0.8 * 12.0)
 val FAR_OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(0.7 * 12.0)
 const val GEAR_RATIO = 1.0

--- a/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerConstants.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerConstants.kt
@@ -2,9 +2,10 @@ package frc.robot.subsystems.intake.roller
 
 import edu.wpi.first.units.Units
 import edu.wpi.first.units.measure.MomentOfInertia
+import edu.wpi.first.units.measure.Voltage
 
-val INTAKE_VOLTAGE = Units.Volts.of(0.4 * 12.0)
-val OUTTAKE_VOLTAGE = Units.Volts.of(0.5 * 12.0)
-val FAR_OUTTAKE_VOLTAGE = Units.Volts.of(0.7 * 12.0)
+val INTAKE_VOLTAGE: Voltage = Units.Volts.of(-0.5 * 12.0)
+val OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(0.8 * 12.0)
+val FAR_OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(0.7 * 12.0)
 const val GEAR_RATIO = 1.0
 val MOMENT_OF_INERTIA: MomentOfInertia = Units.KilogramSquareMeters.of(0.003)

--- a/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerConstants.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerConstants.kt
@@ -2,8 +2,8 @@ package frc.robot.subsystems.intake.roller
 
 import edu.wpi.first.math.geometry.Translation2d
 import edu.wpi.first.units.Units
-import edu.wpi.first.units.measure.MomentOfInertia
-import edu.wpi.first.units.measure.Voltage
+import edu.wpi.first.units.measure.*
+import frc.robot.lib.getTranslation2d
 
 val INTAKE_VOLTAGE: Voltage = Units.Volts.of(-0.7 * 12.0)
 val OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(0.8 * 12.0)

--- a/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerPorts.kt
+++ b/src/main/kotlin/frc/robot/subsystems/intake/roller/RollerPorts.kt
@@ -1,3 +1,3 @@
 package frc.robot.subsystems.intake.roller
 
-const val MOTOR_ID = 0
+const val MOTOR_ID = 12


### PR DESCRIPTION
- **Add constants for canbus names**
- **Oops (used same port for two motors)**
- **Update offsets**
- **Calibrate PID**
- **Calibrate slip current**
- **Calibrate max velocity**
- **Use mxp for navx**
- **Calibrate omega PID**
- **Apply spotless**
- **Update ports**
- **Calibrate constants**
- **Change neutral mode to break**
- **Calibrate PID**
- **Fix tuning position**
- **Calibrate softlimits & pid**
- **Switch to use `PositionVoltage`**
- **Increase INTAKE_VOLTAGE**
