### PR TITLE
Calibrate Gripper

### DIFF
--- a/src/main/kotlin/frc/robot/subsystems/gripper/GripperConstants.kt
+++ b/src/main/kotlin/frc/robot/subsystems/gripper/GripperConstants.kt
@@ -9,9 +9,9 @@ import edu.wpi.first.units.measure.Voltage
 const val GEAR_RATIO = 1.0 // TODO: Replace with real value
 
 val DISTANCE_THRESHOLD: Distance = Units.Centimeters.of(14.2)
-val INTAKE_VOLTAGE: Voltage = Units.Volts.of(0.3) // TODO: Calibrate
-val OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(-0.3) // TODO: Calibrate
-val REMOVE_ALGAE_VOLTAGE: Voltage = Units.Volts.of(0.3) // TODO: Calibrate
+val INTAKE_VOLTAGE: Voltage = Units.Volts.of(5.0)
+val OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(-9.0)
+val REMOVE_ALGAE_VOLTAGE: Voltage = Units.Volts.of(12.0) // TODO: Calibrate
 val STOP_VOLTAGE: Voltage = Units.Volts.zero()
 val MOMENT_OF_INERTIA: MomentOfInertia =
     Units.KilogramSquareMeters.of(0.03) // TODO: Replace with real value

--- a/src/main/kotlin/frc/robot/subsystems/gripper/GripperConstants.kt
+++ b/src/main/kotlin/frc/robot/subsystems/gripper/GripperConstants.kt
@@ -8,7 +8,7 @@ import edu.wpi.first.units.measure.Voltage
 
 const val GEAR_RATIO = 1.0 // TODO: Replace with real value
 
-val DISTANCE_THRESHOLD: Distance = Units.Meter.of(0.19)
+val DISTANCE_THRESHOLD: Distance = Units.Centimeters.of(14.2)
 val INTAKE_VOLTAGE: Voltage = Units.Volts.of(0.3) // TODO: Calibrate
 val OUTTAKE_VOLTAGE: Voltage = Units.Volts.of(-0.3) // TODO: Calibrate
 val REMOVE_ALGAE_VOLTAGE: Voltage = Units.Volts.of(0.3) // TODO: Calibrate

--- a/src/main/kotlin/frc/robot/subsystems/gripper/GripperIOReal.kt
+++ b/src/main/kotlin/frc/robot/subsystems/gripper/GripperIOReal.kt
@@ -51,7 +51,7 @@ class GripperIOReal : GripperIO {
             calculatedDistance = 80.0
         }
 
-        inputs.sensorDistance.mut_replace(Units.Meters.of(calculatedDistance))
+        inputs.sensorDistance.mut_replace(Units.Centimeters.of(calculatedDistance))
         inputs.appliedVoltage.mut_replace(motor.motorVoltage.value)
     }
 }

--- a/src/main/kotlin/frc/robot/subsystems/gripper/GripperIOReal.kt
+++ b/src/main/kotlin/frc/robot/subsystems/gripper/GripperIOReal.kt
@@ -11,11 +11,12 @@ import edu.wpi.first.math.filter.MedianFilter
 import edu.wpi.first.units.Units
 import edu.wpi.first.units.measure.Voltage
 import edu.wpi.first.wpilibj.AnalogInput
+import frc.robot.REEFMASTER_CANBUS_NAME
 
 class GripperIOReal : GripperIO {
     override val inputs = LoggedGripperInputs()
 
-    private val motor = TalonFX(MOTOR_PORT)
+    private val motor = TalonFX(MOTOR_PORT, REEFMASTER_CANBUS_NAME)
     private val control = VoltageOut(0.0).withEnableFOC(true)
 
     private val sensor = AnalogInput(SENSOR_PORT)

--- a/src/main/kotlin/frc/robot/subsystems/gripper/GripperIOReal.kt
+++ b/src/main/kotlin/frc/robot/subsystems/gripper/GripperIOReal.kt
@@ -52,7 +52,9 @@ class GripperIOReal : GripperIO {
             calculatedDistance = 80.0
         }
 
-        inputs.sensorDistance.mut_replace(Units.Centimeters.of(calculatedDistance))
+        inputs.sensorDistance.mut_replace(
+            Units.Centimeters.of(calculatedDistance)
+        )
         inputs.appliedVoltage.mut_replace(motor.motorVoltage.value)
     }
 }

--- a/src/main/kotlin/frc/robot/subsystems/gripper/GripperPorts.kt
+++ b/src/main/kotlin/frc/robot/subsystems/gripper/GripperPorts.kt
@@ -1,4 +1,4 @@
 package frc.robot.subsystems.gripper
 
-const val MOTOR_PORT = 8 // TODO: Put in real value
-const val SENSOR_PORT = 2
+const val MOTOR_PORT = 16 // TODO: Put in real value
+const val SENSOR_PORT = 3


### PR DESCRIPTION
- **Add constants for canbus names**
- **Oops (used same port for two motors)**
- **Update offsets**
- **Calibrate PID**
- **Calibrate slip current**
- **Calibrate max velocity**
- **Use mxp for navx**
- **Calibrate omega PID**
- **Apply spotless**
- **Calibrate `DISTANCE_THRESHOLD`**
- **Fix wrong units in GripperIOReal sensor distance calculation**
- **Correct ports**
- **Calibrate Gripper Constants**
- **Add correct canbus assignment**
